### PR TITLE
Implement "filter" option

### DIFF
--- a/lib/Test/File/Contents.pm
+++ b/lib/Test/File/Contents.pm
@@ -442,7 +442,8 @@ sub _slurp {
     return '' if eof $fh;
     # Don't use `local $/; return <$fh>;`, it does not work on Windows.
     # See https://rt.perl.org/Ticket/Display.html?id=127668 for details.
-    return join '', <$fh>;
+    my $filter = $opts->{filter};
+    return join '', $filter ? map{ $filter->($_) } <$fh> : <$fh>;
 }
 
 sub _resolve {

--- a/lib/Test/File/Contents.pm
+++ b/lib/Test/File/Contents.pm
@@ -183,7 +183,7 @@ sub file_contents_eq_or_diff {
     my $fn = _resolve($file);
     $desc ||= "$file contents equal to string";
 
-    my $have = _slurp($fn, $opts->{encoding});
+    my $have = _slurp($fn, $opts);
     if (defined $have) {
         return $Test->ok($have eq $want, $desc) || $Test->diag(
             diff \$have, \$want, {
@@ -406,7 +406,7 @@ sub _files_eq {
     my @contents;
     for my $f ($f1, $f2) {
         my $file = _resolve($f);
-        push @contents => _slurp($file, $opts->{encoding});
+        push @contents => _slurp($file, $opts);
         next if defined $contents[-1];
         return $Test->ok(0, $desc)
             || $Test->diag("    Could not open file $file: $!");
@@ -422,7 +422,7 @@ sub _compare {
     my $file = _resolve(shift);
     my ($code, $opts, $desc, $err) = @_;
     local $Test::Builder::Level = 2;
-    my $contents = _slurp($file, $opts->{encoding});
+    my $contents = _slurp($file, $opts);
     if (defined $contents) {
         return $Test->ok(scalar $code->($contents), $desc)
             || $Test->diag("    $err");
@@ -433,7 +433,8 @@ sub _compare {
 }
 
 sub _slurp {
-    my ($file, $encoding) = @_;
+    my ($file, $opts) = @_;
+    my $encoding = $opts->{encoding};
     my $layer = !$encoding  ? ''
         : $encoding =~ '^:' ? $encoding
         :                     ":encoding($encoding)";

--- a/lib/Test/File/Contents.pm
+++ b/lib/Test/File/Contents.pm
@@ -190,7 +190,7 @@ sub file_contents_eq_or_diff {
                 CONTEXT     => $opts->{context},
                 STYLE       => $opts->{style},
                 FILENAME_A  => $file,
-                FILENAME_B  => "Want",
+                FILENAME_B  => 'Want',
             }
         );
     } else {


### PR DESCRIPTION
This draft pull request refers to https://rt.cpan.org/Public/Bug/Display.html?id=13719. I am unsure, if the final statement in the private `_slurp()` function should be

`return join '', $filter ? map{ $filter->($_) } <$fh> : <$fh>;`

or

`return join '', $filter ? map{ $filter->() } <$fh> : <$fh>;`

The second (last) alternative uses the `$_` map iterator variable implicitly inside of the `$filter` code reference. I haven't updated the documention yet and although I have already implemented a single test I have not yet added it to this pull request because I wanted to wait for your feedback first.
